### PR TITLE
fix ipmitool location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM frolvlad/alpine-glibc
 
-RUN apk add --update ca-certificates \
-    && rm -rf /var/cache/apk/*\
+RUN apk add --no-cache ca-certificates \
     && mkdir /embedded
 
 ADD ./mayu-infopusher /mayu-infopusher

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --update ca-certificates \
     && mkdir /embedded
 
 ADD ./mayu-infopusher /mayu-infopusher
-ADD ./embedded/* /embedded/
+ADD ./embedded/ipmitool /embedded/
 
 ENTRYPOINT ["/mayu-infopusher"]
 CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM frolvlad/alpine-glibc
 
 RUN apk add --update ca-certificates \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/*\
+    && mkdir /embedded
 
 ADD ./mayu-infopusher /mayu-infopusher
-ADD ./embedded/ /embedded
+ADD ./embedded/* /embedded/
 
 ENTRYPOINT ["/mayu-infopusher"]
 CMD [ "--help" ]


### PR DESCRIPTION
unfortunately  Dockerfile was wrong, and `ipmitool` in `emebedded` was not added to image
